### PR TITLE
fix: resolve issue with locale update in `AwesomeCalenDartDaysView` widget

### DIFF
--- a/lib/src/widgets/awesome_calendart_days_view.dart
+++ b/lib/src/widgets/awesome_calendart_days_view.dart
@@ -53,6 +53,16 @@ class _AwesomeCalenDartDaysViewState extends State<AwesomeCalenDartDaysView> {
   }
 
   @override
+  void didUpdateWidget(covariant AwesomeCalenDartDaysView oldWidget) {
+    if (oldWidget.locale != widget.locale) {
+      weekDays = widget.displayFullMonthName
+          ? AwesomeDateUtils.getFullWeekdayNames(widget.locale)
+          : AwesomeDateUtils.getShortWeekdayNames(widget.locale);
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       children: [


### PR DESCRIPTION
This pull request includes update to the `AwesomeCalenDartDaysView` widget in the `lib/src/widgets/awesome_calendart_days_view.dart` file. The update ensures that the widget properly handles changes to the `locale` property.

Key change:

* Added the `didUpdateWidget` method to update the `weekDays` variable when the `locale` property changes, ensuring that the correct weekday names are displayed