### PR TITLE
feat(i18n): Add Polish locale

### DIFF
--- a/lib/src/data/locale.dart
+++ b/lib/src/data/locale.dart
@@ -4,4 +4,5 @@ enum LocaleType {
   de,
   es,
   it,
+  pl,
 }

--- a/lib/src/utils/date_utils.dart
+++ b/lib/src/utils/date_utils.dart
@@ -39,6 +39,8 @@ class AwesomeDateUtils {
         return ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'];
       case LocaleType.it:
         return ['Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab', 'Dom'];
+      case LocaleType.pl:
+        return ['Pon', 'Wto', 'Śro', 'Czw', 'Pią', 'Sob', 'Nie'];
     }
   }
 
@@ -93,6 +95,16 @@ class AwesomeDateUtils {
           'Venerdì',
           'Sabato',
           'Domenica'
+        ];
+      case LocaleType.pl:
+        return [
+          'Poniedziałek',
+          'Wtorek',
+          'Środa',
+          'Czwartek',
+          'Piątek',
+          'Sobota',
+          'Niedziela'
         ];
     }
   }
@@ -173,6 +185,21 @@ class AwesomeDateUtils {
           'Ottobre',
           'Novembre',
           'Dicembre'
+        ];
+      case LocaleType.pl:
+        return [
+          'Styczeń',
+          'Luty',
+          'Marzec',
+          'Kwiecień',
+          'Maj',
+          'Czerwiec',
+          'Lipiec',
+          'Sierpień',
+          'Wrzesień',
+          'Październik',
+          'Listopad',
+          'Grudzień'
         ];
     }
   }


### PR DESCRIPTION
This pull request introduces support for the Polish locale in the `AwesomeDateUtils` class. The most important changes include adding the Polish locale to the `LocaleType` enum and updating methods to return Polish names for days of the week and months.

Locale support updates:

* [`lib/src/data/locale.dart`](diffhunk://#diff-6602617bb5a73c9bcbc36b9cdb74594bc0b3ad9f0e80e18c3477dca824e47c9aR7): Added `pl` to the `LocaleType` enum.

Polish locale implementation in date utilities:

* [`lib/src/utils/date_utils.dart`](diffhunk://#diff-6e50da575c06d3152263e462c35c1c8c307a098ece8215deb1525cc7136d7ee4R42-R43): Updated the `getDaysOfWeek` method to return Polish names for the days of the week.
* [`lib/src/utils/date_utils.dart`](diffhunk://#diff-6e50da575c06d3152263e462c35c1c8c307a098ece8215deb1525cc7136d7ee4R99-R108): Updated the `getDaysOfWeekFull` method to return full Polish names for the days of the week.
* [`lib/src/utils/date_utils.dart`](diffhunk://#diff-6e50da575c06d3152263e462c35c1c8c307a098ece8215deb1525cc7136d7ee4R189-R203): Updated the `getMonthsOfYear` method to return Polish names for the months.