### PR TITLE
fix: resolve issue with locale update in `AwesomeCalenDartDaysView` widget

### DIFF
--- a/lib/src/widgets/awesome_calendart_days_view.dart
+++ b/lib/src/widgets/awesome_calendart_days_view.dart
@@ -45,6 +45,16 @@ class _AwesomeCalenDartDaysViewState extends State<AwesomeCalenDartDaysView> {
   }
 
   @override
+  void didUpdateWidget(covariant AwesomeCalenDartDaysView oldWidget) {
+    if (oldWidget.locale != widget.locale) {
+      weekDays = widget.displayFullMonthName
+          ? AwesomeDateUtils.getFullWeekdayNames(widget.locale)
+          : AwesomeDateUtils.getShortWeekdayNames(widget.locale);
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
   void initState() {
     super.initState();
     weekDays = widget.displayFullMonthName


### PR DESCRIPTION
This pull request includes an update to the `AwesomeCalenDartDaysView` widget to handle changes in locale dynamically. The most important changes include adding the `didUpdateWidget` method to update the weekday names when the locale changes.

Changes to handle locale updates:

* [`lib/src/widgets/awesome_calendart_days_view.dart`](diffhunk://#diff-6875cd541a5f0b649fec382e119bf28fc15d2fca2af69a3d8f5423f7b19acabbR47-R56): Added the `didUpdateWidget` method to update `weekDays` when the locale changes. This ensures that the weekday names are updated correctly based on the new locale