### PR TITLE
fix: Correct previous month selection

### DIFF
--- a/lib/src/widgets/awesome_calendart_days_view.dart
+++ b/lib/src/widgets/awesome_calendart_days_view.dart
@@ -35,7 +35,7 @@ class _AwesomeCalenDartDaysViewState extends State<AwesomeCalenDartDaysView> {
   late List<String> weekDays;
 
   _getPreviousMonth() {
-    DateTime newDate = AwesomeDateUtils.getPreviousMonth(widget.selectedDate);
+    DateTime newDate = AwesomeDateUtils.getPreviousMonth(widget.selectedMonth);
     widget.updateSelectedMonth(newDate);
   }
 


### PR DESCRIPTION
This pull request includes a minor but important change to the `AwesomeCalenDartDaysView` widget in the `lib/src/widgets/awesome_calendart_days_view.dart` file. The change ensures that the `_getPreviousMonth` method uses the correct property, `selectedMonth`, instead of `selectedDate`.

## Problem

The method `_getPreviousMonth()` incorrectly determines the previous month based on the selected day instead of the selected month. This causes incorrect back month navigation in the calendar.

## Changes

* [`lib/src/widgets/awesome_calendart_days_view.dart`](diffhunk://#diff-6875cd541a5f0b649fec382e119bf28fc15d2fca2af69a3d8f5423f7b19acabbL38-R38): Modified the `_getPreviousMonth` method to use `widget.selectedMonth` instead of `widget.selectedDate` to correctly update the selected month.